### PR TITLE
Use hex-encoding for HMAC-SHA1 signature

### DIFF
--- a/src/xyz/pushpad/Pushpad.java
+++ b/src/xyz/pushpad/Pushpad.java
@@ -23,7 +23,7 @@ public class Pushpad {
       Mac mac = Mac.getInstance("HmacSHA1");
       mac.init(signingKey);
       byte[] rawHmac = mac.doFinal(data.getBytes());
-      encoded = DatatypeConverter.printHexBinary(rawHmac);
+      encoded = DatatypeConverter.printHexBinary(rawHmac).toLowerCase();
     } catch (NoSuchAlgorithmException | InvalidKeyException e) { 
       e.printStackTrace();
     }

--- a/src/xyz/pushpad/Pushpad.java
+++ b/src/xyz/pushpad/Pushpad.java
@@ -5,7 +5,7 @@ import javax.crypto.Mac;
 import java.security.SignatureException;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
-import java.util.Base64;
+import javax.xml.bind.DatatypeConverter;
 
 public class Pushpad {
   public String authToken;
@@ -23,7 +23,7 @@ public class Pushpad {
       Mac mac = Mac.getInstance("HmacSHA1");
       mac.init(signingKey);
       byte[] rawHmac = mac.doFinal(data.getBytes());
-      encoded = Base64.getEncoder().withoutPadding().encodeToString(rawHmac);
+      encoded = DatatypeConverter.printHexBinary(rawHmac);
     } catch (NoSuchAlgorithmException | InvalidKeyException e) { 
       e.printStackTrace();
     }


### PR DESCRIPTION
As described in the documentation ( https://pushpad.xyz/docs/identifying_users ), the signature should be hex-encoded. Base64-encoded signatures get rejected.