### PR TITLE
Support UTF-8 characters in notifications

### DIFF
--- a/src/xyz/pushpad/Notification.java
+++ b/src/xyz/pushpad/Notification.java
@@ -99,7 +99,9 @@ public class Notification {
 
       // Send request
       DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-      wr.writeBytes(reqBody);
+      BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(wr, "UTF-8"));
+      writer.write(reqBody);
+      writer.close();
       wr.close();
 
       // Get Response  


### PR DESCRIPTION
UTF-8 characters contained in a notification were not correctly written into the output stream and caused an HTTP response status of 500